### PR TITLE
Add msvc build and windows compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PREFIX=/opt/duo
+PREFIX=/opt/duo/
 CFLAGS += -DPREFIX='"$(PREFIX)"'
 
 ifdef USE_PERL

--- a/duo_openvpn.c
+++ b/duo_openvpn.c
@@ -95,6 +95,7 @@ auth_user_pass_verify(struct context *ctx, const char *args[], const char *envp[
     char filename[128];
     
 	
+
 	control = get_env("auth_control_file", envp);
 	username = get_env("common_name", envp);
 	password = get_env("password", envp);
@@ -145,7 +146,7 @@ auth_user_pass_verify(struct context *ctx, const char *args[], const char *envp[
     
 #if !defined(_MSVC)
     
-    strcat(filename, STR(PREFIX));
+    strcpy(filename, PREFIX);
     strcat(filename, DUO_SCRIPT);
     
     argv[0] = INTERPRETER;

--- a/duo_openvpn.c
+++ b/duo_openvpn.c
@@ -4,6 +4,7 @@
 #include <stdint.h>
 #include <signal.h>
 
+// the compiler option _MSVC must be defined for MSVC builds
 #if defined(_MSVC)
 # include <io.h>
 # define SETENV(x, y) setenv_msvc(x, y)
@@ -25,15 +26,16 @@
 #define DUO_SCRIPT "duo_openvpn.pl"
 #endif
 
+// this is to make sure the compiler option string is handled correctly on msvc builds
 #define XSTR(x) #x
 #define STR(x) XSTR(x)
 
 struct context {
-	char *ikey;
-	char *skey;
-	char *host;
-	char *proxy_host;
-	char *proxy_port;
+    char *ikey;
+    char *skey;
+    char *host;
+    char *proxy_host;
+    char *proxy_port;
 };
 
 static void 
@@ -53,7 +55,7 @@ setenv_posix(const char *name, const char *value)
 static void 
 unsetenv_msvc(const char *name)
 {
-    // No equivalent found yet
+    // No equivalent found
 }
 
 static void 
@@ -65,87 +67,90 @@ unsetenv_posix(const char *name)
 static const char *
 get_env(const char *name, const char *envp[])
 {
-	int i, namelen;
-	const char *cp;
-	
-	if (envp) {
-		namelen = strlen(name);
-		for (i = 0; envp[i]; ++i) {
-			if (!strncmp(envp[i], name, namelen)) {
-				cp = envp[i] + namelen;
-				if (*cp == '=') {
-					return cp + 1;
-				}
-			}
-		}
-	}
-	return NULL;
+    int i, namelen;
+    const char *cp;
+    
+    if (envp) {
+        namelen = strlen(name);
+        for (i = 0; envp[i]; ++i) {
+            if (!strncmp(envp[i], name, namelen)) {
+                cp = envp[i] + namelen;
+                if (*cp == '=') {
+                    return cp + 1;
+                }
+            }
+        }
+    }
+    return NULL;
 }
 
 static int
 auth_user_pass_verify(struct context *ctx, const char *args[], const char *envp[])
 {
-	int pid;
-	const char *control, *username, *password, *ipaddr;
-    char *argv[3]; // = { INTERPRETER, DUO_SCRIPT_PATH, NULL };
+    // variables only used to fork the python process on posix builds
+    int pid;
+    char *argv[3];
     
+    // variables used to run the python script with _popen on msvc builds
     FILE   *pPipe;
     char   psBuffer[128];
     
     char filename[128];
     
-	
+    // options to pass to our script
+    const char *control, *username, *password, *ipaddr;
+    
+    control = get_env("auth_control_file", envp);
+    username = get_env("common_name", envp);
+    password = get_env("password", envp);
+    ipaddr = get_env("untrusted_ip", envp);
 
-	control = get_env("auth_control_file", envp);
-	username = get_env("common_name", envp);
-	password = get_env("password", envp);
-	ipaddr = get_env("untrusted_ip", envp);
-
-	if (!control || !username || !password || !ipaddr) {
-		return OPENVPN_PLUGIN_FUNC_ERROR;
-	}
+    if (!control || !username || !password || !ipaddr) {
+        return OPENVPN_PLUGIN_FUNC_ERROR;
+    }
 
 #if !defined(_MSVC)
     
-	/* prevent leaving behind zombies */
-	signal(SIGCHLD, SIG_IGN);
+    /* prevent leaving behind zombies */
+    signal(SIGCHLD, SIG_IGN);
 
     pid = fork();
-	if (pid < 0) {
-		return OPENVPN_PLUGIN_FUNC_ERROR;
-	}
+    if (pid < 0) {
+        return OPENVPN_PLUGIN_FUNC_ERROR;
+    }
 
-	if (pid > 0) {
-		return OPENVPN_PLUGIN_FUNC_DEFERRED;
-	}
+    if (pid > 0) {
+        return OPENVPN_PLUGIN_FUNC_DEFERRED;
+    }
     
 #endif    
-	
-	if (ctx->ikey && ctx->skey && ctx->host) {
-		SETENV("ikey", ctx->ikey);
-		SETENV("skey", ctx->skey);
-		SETENV("host", ctx->host);
-		if (ctx->proxy_host) {
-			SETENV("proxy_host", ctx->proxy_host);
-		}
-		else {
+    
+    if (ctx->ikey && ctx->skey && ctx->host) {
+        SETENV("ikey", ctx->ikey);
+        SETENV("skey", ctx->skey);
+        SETENV("host", ctx->host);
+        if (ctx->proxy_host) {
+            SETENV("proxy_host", ctx->proxy_host);
+        }
+        else {
             UNSETENV("proxy_host");
-		}
-		if (ctx->proxy_port) {
-			SETENV("proxy_port", ctx->proxy_port);
-		}
-		else {
+        }
+        if (ctx->proxy_port) {
+            SETENV("proxy_port", ctx->proxy_port);
+        }
+        else {
             UNSETENV("proxy_port");
-		}
-	}
+        }
+    }
 
-	SETENV("control", control);
-	SETENV("username", username);
-	SETENV("password", password);
-	SETENV("ipaddr", ipaddr);
+    SETENV("control", control);
+    SETENV("username", username);
+    SETENV("password", password);
+    SETENV("ipaddr", ipaddr);
     
 #if !defined(_MSVC)
     
+    // create our script path from compiler options
     strcpy(filename, PREFIX);
     strcat(filename, DUO_SCRIPT);
     
@@ -153,29 +158,36 @@ auth_user_pass_verify(struct context *ctx, const char *args[], const char *envp[
     argv[1] = filename;
     argv[2] = NULL;
     
+    // execute the python script and have it take over the process
     execvp(argv[0], argv);
-	exit(1);
+    
+    // execution should not get here, exit with error
+    exit(1);
     
 #else
-    
+    // msvc builds create our command string from compiler options
+    // TODO: test whether this works on posix builds as well
     strcpy(filename, INTERPRETER);
     strcat(filename, " ");
     strcat(filename, STR(PREFIX));
     strcat(filename, DUO_SCRIPT);
 
+    // execute our python script
     if( (pPipe = _popen( filename, "rt" )) == NULL )
       return OPENVPN_PLUGIN_FUNC_ERROR;
 
-    /* Read pipe until end of file, or an error occurs. */
+    // read the script output until eof or error
     while(fgets(psBuffer, 128, pPipe)) { } 
 
-    /* Close pipe and print return value of pPipe or exit */
+    // close pipe and print return value of pPipe or exit with error
     if (feof( pPipe))
     {
+      // return the return value of our script execution
       return _pclose( pPipe );
     }
     else
     {
+      // problem with script execution, return plugin error
       exit(1);
     }
     
@@ -186,63 +198,63 @@ auth_user_pass_verify(struct context *ctx, const char *args[], const char *envp[
 OPENVPN_EXPORT int
 openvpn_plugin_func_v2(openvpn_plugin_handle_t handle, const int type, const char *argv[], const char *envp[], void *per_client_context, struct openvpn_plugin_string_list **return_list)
 {
-	struct context *ctx = (struct context *) handle;
+    struct context *ctx = (struct context *) handle;
 
-	if (type == OPENVPN_PLUGIN_AUTH_USER_PASS_VERIFY) {
-		return auth_user_pass_verify(ctx, argv, envp);
-	} else {
-		return OPENVPN_PLUGIN_FUNC_ERROR;
-	}
+    if (type == OPENVPN_PLUGIN_AUTH_USER_PASS_VERIFY) {
+        return auth_user_pass_verify(ctx, argv, envp);
+    } else {
+        return OPENVPN_PLUGIN_FUNC_ERROR;
+    }
 }
 
 OPENVPN_EXPORT openvpn_plugin_handle_t
 openvpn_plugin_open_v2(unsigned int *type_mask, const char *argv[], const char *envp[], struct openvpn_plugin_string_list **return_list)
 {
-	struct context *ctx;
+    struct context *ctx;
     
-	ctx = (struct context *) calloc(1, sizeof(struct context));
+    ctx = (struct context *) calloc(1, sizeof(struct context));
 
-	if (argv[1] && argv[2] && argv[3]) {
-		ctx->ikey = strdup(argv[1]);
-		ctx->skey = strdup(argv[2]);
-		ctx->host = strdup(argv[3]);
-	}
+    if (argv[1] && argv[2] && argv[3]) {
+        ctx->ikey = strdup(argv[1]);
+        ctx->skey = strdup(argv[2]);
+        ctx->host = strdup(argv[3]);
+    }
 
-	/* Passing proxy_host even if proxy_port is not present
-	 * generates a more informative log message.
-	 */
-	if (argv[4]) {
-		ctx->proxy_host = strdup(argv[4]);
-		if (argv[5]) {
-			ctx->proxy_port = strdup(argv[5]);
-		}
-		else {
-			ctx->proxy_port = NULL;
-		}
-	}
-	else {
-		ctx->proxy_host = NULL;
-		ctx->proxy_port = NULL;
-	}
+    /* Passing proxy_host even if proxy_port is not present
+     * generates a more informative log message.
+     */
+    if (argv[4]) {
+        ctx->proxy_host = strdup(argv[4]);
+        if (argv[5]) {
+            ctx->proxy_port = strdup(argv[5]);
+        }
+        else {
+            ctx->proxy_port = NULL;
+        }
+    }
+    else {
+        ctx->proxy_host = NULL;
+        ctx->proxy_port = NULL;
+    }
 
-	*type_mask = OPENVPN_PLUGIN_MASK(OPENVPN_PLUGIN_AUTH_USER_PASS_VERIFY);
+    *type_mask = OPENVPN_PLUGIN_MASK(OPENVPN_PLUGIN_AUTH_USER_PASS_VERIFY);
 
-	return (openvpn_plugin_handle_t) ctx;
+    return (openvpn_plugin_handle_t) ctx;
 }
 
 OPENVPN_EXPORT void
 openvpn_plugin_close_v1(openvpn_plugin_handle_t handle)
 {
-	struct context *ctx = (struct context *) handle;
+    struct context *ctx = (struct context *) handle;
 
-	free(ctx->ikey);
-	free(ctx->skey);
-	free(ctx->host);
-	if (ctx->proxy_host) {
-		free(ctx->proxy_host);
-	}
-	if (ctx->proxy_port) {
-		free(ctx->proxy_port);
-	}
-	free(ctx);
+    free(ctx->ikey);
+    free(ctx->skey);
+    free(ctx->host);
+    if (ctx->proxy_host) {
+        free(ctx->proxy_host);
+    }
+    if (ctx->proxy_port) {
+        free(ctx->proxy_port);
+    }
+    free(ctx);
 }

--- a/openvpn-plugin.h
+++ b/openvpn-plugin.h
@@ -121,10 +121,12 @@ typedef void *openvpn_plugin_handle_t;
 /*
  * For Windows (needs to be modified for MSVC)
  */
-#if defined(__MINGW32_VERSION) && !defined(OPENVPN_PLUGIN_H)
-# define OPENVPN_EXPORT __declspec(dllexport)
-#else
-# define OPENVPN_EXPORT
+#if !defined(OPENVPN_PLUGIN_H)
+# if defined(__MINGW32_VERSION) || defined(_MSVC)
+#  define OPENVPN_EXPORT __declspec(dllexport)
+# else
+#  define OPENVPN_EXPORT
+# endif
 #endif
 
 /*

--- a/openvpn-plugin.h
+++ b/openvpn-plugin.h
@@ -119,7 +119,7 @@ typedef void *openvpn_plugin_handle_t;
 #define OPENVPN_PLUGIN_FUNC_DEFERRED 2
 
 /*
- * For Windows (needs to be modified for MSVC)
+ * For Windows MING32 and MSVC (compiler option _MSVC must be defined)
  */
 #if !defined(OPENVPN_PLUGIN_H)
 # if defined(__MINGW32_VERSION) || defined(_MSVC)

--- a/winbuild_msvc.cmd
+++ b/winbuild_msvc.cmd
@@ -1,0 +1,3 @@
+set PREFIX=E:\\workspace\\duo_openvpn\\
+
+cl.exe /D_MSVC /DPREFIX=%PREFIX% /D_USRDLL /D_WINDLL duo_openvpn.c duo_openvpn.obj /link /DLL /OUT:duo_openvpn.dll


### PR DESCRIPTION
Function calls such as setenv and fork are not native to the windows C libraries and fork has no equivalent. This module leaves the posix-related codes alone to maintain backwards compatibility, while enabling msvc builds. A script to build on windows with msvc is also added.
