### PR TITLE
Ignoring SIG_CHLD breaks external scripts

### DIFF
--- a/duo_openvpn.c
+++ b/duo_openvpn.c
@@ -68,35 +68,37 @@ auth_user_pass_verify(struct context *ctx, const char *args[], const char *envp[
 		return OPENVPN_PLUGIN_FUNC_ERROR;
 	}
 
-	if (pid > 0) {
-		return OPENVPN_PLUGIN_FUNC_DEFERRED;
-	}
-	
-	if (ctx->ikey && ctx->skey && ctx->host) {
-		setenv("ikey", ctx->ikey, 1);
-		setenv("skey", ctx->skey, 1);
-		setenv("host", ctx->host, 1);
-		if (ctx->proxy_host) {
-			setenv("proxy_host", ctx->proxy_host, 1);
-		}
-		else {
-			unsetenv("proxy_host");
-		}
-		if (ctx->proxy_port) {
-			setenv("proxy_port", ctx->proxy_port, 1);
-		}
-		else {
-			unsetenv("proxy_port");
-		}
-	}
+        if (pid > 0) {
+                int status;
+                waitpid(pid, &status, 0);
+                return OPENVPN_PLUGIN_FUNC_DEFERRED;
+        } else {
+                if (ctx->ikey && ctx->skey && ctx->host) {
+                        setenv("ikey", ctx->ikey, 1);
+                        setenv("skey", ctx->skey, 1);
+                        setenv("host", ctx->host, 1);
+                        if (ctx->proxy_host) {
+                                setenv("proxy_host", ctx->proxy_host, 1);
+                        }
+                        else {
+                                unsetenv("proxy_host");
+                        }
+                        if (ctx->proxy_port) {
+                                setenv("proxy_port", ctx->proxy_port, 1);
+                        }
+                        else {
+                                unsetenv("proxy_port");
+                        }
+                }
 
-	setenv("control", control, 1);
-	setenv("username", username, 1);
-	setenv("password", password, 1);
-	setenv("ipaddr", ipaddr, 1);
+                setenv("control", control, 1);
+                setenv("username", username, 1);
+                setenv("password", password, 1);
+                setenv("ipaddr", ipaddr, 1);
 
-	execvp(argv[0], argv);
-	exit(1);
+                execvp(argv[0], argv);
+                exit(1);
+        }
 }
 
 OPENVPN_EXPORT int

--- a/duo_openvpn.c
+++ b/duo_openvpn.c
@@ -60,9 +60,6 @@ auth_user_pass_verify(struct context *ctx, const char *args[], const char *envp[
 		return OPENVPN_PLUGIN_FUNC_ERROR;
 	}
 
-	/* prevent leaving behind zombies */
-	signal(SIGCHLD, SIG_IGN);
-
 	pid = fork();
 	if (pid < 0) {
 		return OPENVPN_PLUGIN_FUNC_ERROR;


### PR DESCRIPTION
Related issue: #9 

Duo waits for the execvp Python/Perl process to exit successfully, and generate an error if it fails. 