### PR TITLE
Fix SIG_CHLD issue causing all external scripts to fail

### DIFF
--- a/duo_openvpn.c
+++ b/duo_openvpn.c
@@ -30,7 +30,7 @@ get_env(const char *name, const char *envp[])
 {
 	int i, namelen;
 	const char *cp;
-	
+
 	if (envp) {
 		namelen = strlen(name);
 		for (i = 0; envp[i]; ++i) {
@@ -51,7 +51,7 @@ auth_user_pass_verify(struct context *ctx, const char *args[], const char *envp[
 	int pid;
 	const char *control, *username, *password, *ipaddr;
 	char *argv[] = { INTERPRETER, DUO_SCRIPT_PATH, NULL };
-	
+
 	control = get_env("auth_control_file", envp);
 	username = get_env("common_name", envp);
 	password = get_env("password", envp);
@@ -121,7 +121,7 @@ OPENVPN_EXPORT openvpn_plugin_handle_t
 openvpn_plugin_open_v2(unsigned int *type_mask, const char *argv[], const char *envp[], struct openvpn_plugin_string_list **return_list)
 {
 	struct context *ctx;
-	
+
 	ctx = (struct context *) calloc(1, sizeof(struct context));
 
 	if (argv[1] && argv[2] && argv[3]) {

--- a/duo_openvpn.c
+++ b/duo_openvpn.c
@@ -84,12 +84,12 @@ auth_user_pass_verify(struct context *ctx, const char *args[], const char *envp[
 
 	pid = fork();
 	if (pid < 0) {
-		return OPENVPN_PLUGIN_FUNC_ERROR;
+		exit(OPENVPN_PLUGIN_FUNC_ERROR);
 	}
 
 	if (pid > 0) {
 		/* first child forked ok, pass deferred return up to parent openvpn process */
-		return OPENVPN_PLUGIN_FUNC_DEFERRED;
+		exit(OPENVPN_PLUGIN_FUNC_DEFERRED);
 	}
 
 	/* second child daemonizes so PID 1 can reap */


### PR DESCRIPTION
This pull request removes the call to signal() that ignores SIG_CHLD, and daemonizes the child instead.

The goal with ignoring SIG_CHLD, according to comments, was to prevent the child from becoming a zombie once its work was complete.  It would do this because the parent had returned, giving openvpn server the OPENVPN_PLUGIN_FUNC_DEFERRED return value.

The usual way of preventing zombies when spawning and abandoning child processes, however, is to daemonize the child by giving it its own process group and closing any common file descriptors.  This pull request accomplishes that.

It also includes a small whitespace-only patch that removes trailing whitespace (three lines with just a tab in them).  It's not strictly necessary, but good coding practice...