### PR TITLE
Added sys/wait.h to prevent the plugin from crashing OpenVPN on FreeBSD

### DIFF
--- a/duo_openvpn.c
+++ b/duo_openvpn.c
@@ -1,4 +1,5 @@
 #include <sys/stat.h>
+#include <sys/wait.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>


### PR DESCRIPTION
sys/wait.h is needed on FreeBSD to avoid compile-time warnings and crashing of the OpenVPN server with the following error:

PLUGIN_INIT: could not load plugin shared object /opt/duo/duo_openvpn.so: /opt/duo/duo_openvpn.so: Undefined symbol "WIFEXITED": Invalid argument (errno=22) 