### PR TITLE
Add support to configure python 2.7 on BSD 10 (PFsense)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,10 @@ else
 SCRIPT_NAME=duo_openvpn.py
 endif
 
+ifdef IS_BSD_10
+CFLAGS += -DIS_BSD_10
+endif
+
 all: duo_openvpn.so
 
 duo_openvpn.o: duo_openvpn.c

--- a/duo_openvpn.c
+++ b/duo_openvpn.c
@@ -11,7 +11,13 @@
 #include "openvpn-plugin.h"
 
 #ifndef USE_PERL
+
+#ifdef  IS_BSD_10
+#define INTERPRETER     "/usr/local/bin/python2.7"
+#else
 #define INTERPRETER     "python"
+#endif
+
 #define DUO_SCRIPT_PATH PREFIX "/duo_openvpn.py"
 #else
 #define INTERPRETER     "perl"


### PR DESCRIPTION
This addresses that last issue on https://github.com/duosecurity/duo_openvpn/issues/12

It has been tested on FreeBSD 10.3 stable both in production and on a vagrant box.