### PR TITLE
Add missing '!' to the shebang in duo_openvpn.pl

### DIFF
--- a/duo_openvpn.pl
+++ b/duo_openvpn.pl
@@ -1,4 +1,4 @@
-#/usr/bin/env perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;


### PR DESCRIPTION
Add missing '!' after initial '#' to make this script run as a perl script instead of be executed by the default interpreter (bash, most often).