### PR TITLE
Don't hard code the script interpreter in duo_openvpn.c

### DIFF
--- a/duo_openvpn.c
+++ b/duo_openvpn.c
@@ -11,10 +11,8 @@
 #include "openvpn-plugin.h"
 
 #ifndef USE_PERL
-#define INTERPRETER     "python"
 #define DUO_SCRIPT_PATH PREFIX "/duo_openvpn.py"
 #else
-#define INTERPRETER     "perl"
 #define DUO_SCRIPT_PATH PREFIX "/duo_openvpn.pl"
 #endif
 
@@ -51,7 +49,7 @@ auth_user_pass_verify(struct context *ctx, const char *args[], const char *envp[
 {
 	int pid;
 	const char *control, *username, *password, *ipaddr;
-	char *argv[] = { INTERPRETER, DUO_SCRIPT_PATH, NULL };
+	char *argv[] = { DUO_SCRIPT_PATH, NULL };
 
 	control = get_env("auth_control_file", envp);
 	username = get_env("common_name", envp);


### PR DESCRIPTION
The scripts themselves specify the interpreter, just execute them. This simplifies dealing with python2 vs python3, only the script needs to be modified, and not the C source.