### PR TITLE
Support Duo challenge for Open VPN username and password based auth

### DIFF
--- a/duo_openvpn.c
+++ b/duo_openvpn.c
@@ -16,28 +16,38 @@
 #define DUO_SCRIPT_PATH PREFIX "/duo_openvpn.pl"
 #endif
 
+static const char *PLUGIN_NAME = "DUO-OPENVPN";
+
 struct context {
 	char *ikey;
 	char *skey;
 	char *host;
 	char *proxy_host;
 	char *proxy_port;
+	plugin_log_t plugin_log;
 };
+
+static const char *
+get_variable(const char *name, const char *value, const char divider)
+{
+	int namelen = strlen(name);
+	if (!strncmp(value, name, namelen)) {
+		const char *prefix = value + namelen;
+		if (*prefix == divider) {
+			return prefix + 1;
+		}
+	}
+	return NULL;
+}
 
 static const char *
 get_env(const char *name, const char *envp[])
 {
-	int i, namelen;
-	const char *cp;
-
 	if (envp) {
-		namelen = strlen(name);
-		for (i = 0; envp[i]; ++i) {
-			if (!strncmp(envp[i], name, namelen)) {
-				cp = envp[i] + namelen;
-				if (*cp == '=') {
-					return cp + 1;
-				}
+		for (int i = 0; envp[i]; ++i) {
+			const char *result = get_variable(name, envp[i], '=');
+			if (NULL != result) {
+				return result;
 			}
 		}
 	}
@@ -126,6 +136,65 @@ auth_user_pass_verify(struct context *ctx, const char *args[], const char *envp[
 	exit(1);
 }
 
+static int
+load_configuration_file(const char *file_path, struct context *ctx)
+{
+	FILE *fp = fopen(file_path, "r");
+
+	if (!fp) {
+		ctx->plugin_log(PLOG_ERR, PLUGIN_NAME, "Could not open configuration file %s", file_path);
+		return 0;
+	}
+
+	char line[255];
+	while (fgets(line, sizeof(line), fp)) {
+		line[strcspn(line, "\r\n")] = 0;
+		if (line[0] == '\0' || line[0] == '#') {
+			continue;
+		}
+
+		if (strlen(line) > 250) {
+			ctx->plugin_log(PLOG_ERR, PLUGIN_NAME, "Configuration line longer than maximum 250 characters. Line starts with %s", line);
+			return 0;
+		}
+
+		const char *potential_ikey = get_variable("integration-key", line, ' ');
+		if (potential_ikey) {
+			ctx->ikey = strdup(potential_ikey);
+			continue;
+		}
+
+		const char *potential_skey = get_variable("secret-key", line, ' ');
+		if (potential_skey) {
+			ctx->skey = strdup(potential_skey);
+			continue;
+		}
+
+		const char *potential_host = get_variable("host", line, ' ');
+		if (potential_host) {
+			ctx->host = strdup(potential_host);
+			continue;
+		}
+
+		const char *potential_proxy_host = get_variable("proxy-host", line, ' ');
+		if (potential_proxy_host) {
+			ctx->host = strdup(potential_proxy_host);
+			continue;
+		}
+
+		const char *potential_proxy_port = get_variable("proxy-port", line, ' ');
+		if (potential_proxy_port) {
+			ctx->proxy_port = strdup(potential_proxy_port);
+			continue;
+		}
+
+		ctx->plugin_log(PLOG_ERR, PLUGIN_NAME, "Unknown configuration entry in file '%s': %s", file_path, line);
+		return 0;
+	}
+	fclose(fp);
+	return 1;
+}
+
 OPENVPN_EXPORT int
 openvpn_plugin_func_v2(openvpn_plugin_handle_t handle, const int type, const char *argv[], const char *envp[], void *per_client_context, struct openvpn_plugin_string_list **return_list)
 {
@@ -138,39 +207,79 @@ openvpn_plugin_func_v2(openvpn_plugin_handle_t handle, const int type, const cha
 	}
 }
 
-OPENVPN_EXPORT openvpn_plugin_handle_t
-openvpn_plugin_open_v2(unsigned int *type_mask, const char *argv[], const char *envp[], struct openvpn_plugin_string_list **return_list)
+OPENVPN_EXPORT int
+openvpn_plugin_open_v3(const int v3structver, const struct openvpn_plugin_args_open_in *args, struct openvpn_plugin_args_open_return *ret)
 {
 	struct context *ctx;
 
 	ctx = (struct context *) calloc(1, sizeof(struct context));
+	ctx->plugin_log = args->callbacks->plugin_log;
 
-	if (argv[1] && argv[2] && argv[3]) {
-		ctx->ikey = strdup(argv[1]);
-		ctx->skey = strdup(argv[2]);
-		ctx->host = strdup(argv[3]);
-	}
+	const char **argv = args->argv;
+	if (argv[1] && strpbrk(argv[1], "=")) {
+		const char *config_file_path = get_env("--config-file", argv);
+		if (config_file_path) {
+			if (argv[2]) {
+				ctx->plugin_log(PLOG_WARN, PLUGIN_NAME, "Plugin is configured with a config-file option and additional parameters, but parameters are not supported alongside a configuration file.");
+				return OPENVPN_PLUGIN_FUNC_ERROR;
+			}
+			if (!load_configuration_file(config_file_path, ctx)) {
+				ctx->plugin_log(PLOG_ERR, PLUGIN_NAME, "Failed to load plugin configuration from file");
+				return OPENVPN_PLUGIN_FUNC_ERROR;
+			}
+		} else {
+			ctx->plugin_log(PLOG_ERR, PLUGIN_NAME, "No 'config-file' parameter found");
+			return OPENVPN_PLUGIN_FUNC_ERROR;
+		}
+	} else {
+		if (argv[1] && argv[2] && argv[3]) {
+			ctx->plugin_log(PLOG_WARN, PLUGIN_NAME, "Plugin is configured with a legacy configuration format. Switch to using 'parameter=value' format to use any new features.");
+			ctx->ikey = strdup(argv[1]);
+			ctx->skey = strdup(argv[2]);
+			ctx->host = strdup(argv[3]);
+		}
 
-	/* Passing proxy_host even if proxy_port is not present
-	 * generates a more informative log message.
-	 */
-	if (argv[4]) {
-		ctx->proxy_host = strdup(argv[4]);
-		if (argv[5]) {
-			ctx->proxy_port = strdup(argv[5]);
+		/* Passing proxy_host even if proxy_port is not present
+		 * generates a more informative log message.
+		 */
+		if (argv[4]) {
+			ctx->proxy_host = strdup(argv[4]);
+			if (argv[5]) {
+				ctx->proxy_port = strdup(argv[5]);
+			}
+			else {
+				ctx->proxy_port = NULL;
+			}
 		}
 		else {
+			ctx->proxy_host = NULL;
 			ctx->proxy_port = NULL;
 		}
 	}
-	else {
-		ctx->proxy_host = NULL;
-		ctx->proxy_port = NULL;
+
+	int success = 1;
+	if (!ctx->host) {
+		ctx->plugin_log(PLOG_ERR, PLUGIN_NAME, "Host is not specified in plugin configuration");
+		success = 0;
+	}
+	if (!ctx->ikey) {
+		ctx->plugin_log(PLOG_ERR, PLUGIN_NAME, "Integration Key is not specified in plugin configuration");
+		success = 0;
+	}
+	if (!ctx->skey) {
+		ctx->plugin_log(PLOG_ERR, PLUGIN_NAME, "Secret Key is not specified in plugin configuration");
+		success = 0;
 	}
 
-	*type_mask = OPENVPN_PLUGIN_MASK(OPENVPN_PLUGIN_AUTH_USER_PASS_VERIFY);
+	if (success != 1) {
+		return OPENVPN_PLUGIN_FUNC_ERROR;
+	}
 
-	return (openvpn_plugin_handle_t) ctx;
+	ctx->plugin_log(PLOG_NOTE, PLUGIN_NAME, "Plugin initialised with host '%s' and integration key '%s'", ctx->host, ctx->ikey);
+
+	ret->type_mask = OPENVPN_PLUGIN_MASK(OPENVPN_PLUGIN_AUTH_USER_PASS_VERIFY);
+	ret->handle = (openvpn_plugin_handle_t) ctx;
+	return OPENVPN_PLUGIN_FUNC_SUCCESS;
 }
 
 OPENVPN_EXPORT void

--- a/duo_openvpn.pl
+++ b/duo_openvpn.pl
@@ -20,12 +20,12 @@ my $API_RESULT_ENROLL = qr/^enroll$/;
 
 openlog 'duo_openvpn.pl', 'pid', 'LOG_AUTH';
 
-my $control  = $ENV{'control'};
-my $username = $ENV{'username'};
-my $password = $ENV{'password'};
-my $ipaddr   = $ENV{'ipaddr'} || '0.0.0.0';
+my $control        = $ENV{'control'};
+my $username       = $ENV{'username'};
+my $challenge_type = $ENV{'challenge_type'};
+my $ipaddr         = $ENV{'ipaddr'} || '0.0.0.0';
 
-if (not $control or not $username or not $password) {
+if (not $control or not $username or not $challenge_type) {
     logger('required environmental variables not found');
     exit 1;
 }
@@ -141,7 +141,7 @@ sub auth {
     my $args = {
         'user'   => $username,
         'factor' => 'auto',
-        'auto'   => $password,
+        'auto'   => $challenge_type,
         'ipaddr' => $ipaddr,
     };
 

--- a/duo_openvpn.py
+++ b/duo_openvpn.py
@@ -358,13 +358,13 @@ def preauth(client, control, username, ipaddr):
         log('unknown preauth result: %s' % result)
         failure(control)
 
-def auth(client, control, username, password, ipaddr):
+def auth(client, control, username, challenge_type, ipaddr):
     log('authentication for %s' % username)
 
     response = client.json_api_call('POST', '/rest/v1/auth', {
         'user': username,
         'factor': 'auto',
-        'auto': password,
+        'auto': challenge_type,
         'ipaddr': ipaddr,
     })
 
@@ -388,7 +388,7 @@ def auth(client, control, username, password, ipaddr):
 def main(Client=Client, environ=os.environ):
     control = environ.get('control')
     username = environ.get('username')
-    password = environ.get('password')
+    challenge_type = environ.get('challenge_type')
     ipaddr = environ.get('ipaddr', '0.0.0.0')
 
     if not control or not username:
@@ -421,15 +421,15 @@ def main(Client=Client, environ=os.environ):
         log(str(e))
         failure(control)
 
-    if not (password or default_factor):
-        log('no password provided and no out-of-band factors '
+    if not (challenge_type or default_factor):
+        log('no challenge type provided and no out-of-band factors '
             'available for username {0:s}'.format(username))
         failure(control)
-    elif not password:
-        password = default_factor
+    elif not challenge_type:
+        challenge_type = default_factor
 
     try:
-        auth(client, control, username, password, ipaddr)
+        auth(client, control, username, challenge_type, ipaddr)
     except Exception as e:
         log(str(e))
         failure(control)

--- a/openvpn-plugin.h
+++ b/openvpn-plugin.h
@@ -5,7 +5,7 @@
  *             packet encryption, packet authentication, and
  *             packet compression.
  *
- *  Copyright (C) 2002-2010 OpenVPN Technologies, Inc. <sales@openvpn.net>
+ *  Copyright (C) 2002-2021 OpenVPN Inc <sales@openvpn.net>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License version 2
@@ -16,13 +16,43 @@
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *  GNU General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this program (see the file COPYING included with this
- *  distribution); if not, write to the Free Software Foundation, Inc.,
- *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#define OPENVPN_PLUGIN_VERSION 2
+#ifndef OPENVPN_PLUGIN_H_
+#define OPENVPN_PLUGIN_H_
+
+#define OPENVPN_PLUGIN_VERSION 3
+
+#ifdef ENABLE_CRYPTO_MBEDTLS
+#include <mbedtls/x509_crt.h>
+#ifndef __OPENVPN_X509_CERT_T_DECLARED
+#define __OPENVPN_X509_CERT_T_DECLARED
+typedef mbedtls_x509_crt openvpn_x509_cert_t;
+#endif
+#else  /* ifdef ENABLE_CRYPTO_MBEDTLS */
+#include <openssl/x509.h>
+#ifndef __OPENVPN_X509_CERT_T_DECLARED
+#define __OPENVPN_X509_CERT_T_DECLARED
+typedef X509 openvpn_x509_cert_t;
+#endif
+#endif
+
+#include <stdarg.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Provide some basic version information to plug-ins at OpenVPN compile time
+ * This is will not be the complete version
+ */
+#define OPENVPN_VERSION_MAJOR @OPENVPN_VERSION_MAJOR@
+#define OPENVPN_VERSION_MINOR @OPENVPN_VERSION_MINOR@
+#define OPENVPN_VERSION_PATCH "@OPENVPN_VERSION_PATCH@"
 
 /*
  * Plug-in types.  These types correspond to the set of script callbacks
@@ -53,7 +83,7 @@
  *
  * FUNC: openvpn_plugin_func_v1 OPENVPN_PLUGIN_CLIENT_CONNECT_V2
  * FUNC: openvpn_plugin_func_v1 OPENVPN_PLUGIN_LEARN_ADDRESS
- * 
+ *
  * [Client session ensues]
  *
  * For each "TLS soft reset", according to reneg-sec option (or similar):
@@ -64,7 +94,7 @@
  *                                                     in the server chain)
  * FUNC: openvpn_plugin_func_v1 OPENVPN_PLUGIN_AUTH_USER_PASS_VERIFY
  * FUNC: openvpn_plugin_func_v1 OPENVPN_PLUGIN_TLS_FINAL
- * 
+ *
  * [If OPENVPN_PLUGIN_AUTH_USER_PASS_VERIFY returned OPENVPN_PLUGIN_FUNC_DEFERRED,
  * we expect that authentication is verified via auth_control_file within
  * the number of seconds defined by the "hand-window" option.  Data channel traffic
@@ -86,19 +116,22 @@
  * FUNC: openvpn_plugin_client_destructor_v1 (top-level "generic" client)
  * FUNC: openvpn_plugin_close_v1
  */
-#define OPENVPN_PLUGIN_UP                    0
-#define OPENVPN_PLUGIN_DOWN                  1
-#define OPENVPN_PLUGIN_ROUTE_UP              2
-#define OPENVPN_PLUGIN_IPCHANGE              3
-#define OPENVPN_PLUGIN_TLS_VERIFY            4
-#define OPENVPN_PLUGIN_AUTH_USER_PASS_VERIFY 5
-#define OPENVPN_PLUGIN_CLIENT_CONNECT        6
-#define OPENVPN_PLUGIN_CLIENT_DISCONNECT     7
-#define OPENVPN_PLUGIN_LEARN_ADDRESS         8
-#define OPENVPN_PLUGIN_CLIENT_CONNECT_V2     9
-#define OPENVPN_PLUGIN_TLS_FINAL             10
-#define OPENVPN_PLUGIN_ENABLE_PF             11
-#define OPENVPN_PLUGIN_N                     12
+#define OPENVPN_PLUGIN_UP                        0
+#define OPENVPN_PLUGIN_DOWN                      1
+#define OPENVPN_PLUGIN_ROUTE_UP                  2
+#define OPENVPN_PLUGIN_IPCHANGE                  3
+#define OPENVPN_PLUGIN_TLS_VERIFY                4
+#define OPENVPN_PLUGIN_AUTH_USER_PASS_VERIFY     5
+#define OPENVPN_PLUGIN_CLIENT_CONNECT            6
+#define OPENVPN_PLUGIN_CLIENT_DISCONNECT         7
+#define OPENVPN_PLUGIN_LEARN_ADDRESS             8
+#define OPENVPN_PLUGIN_CLIENT_CONNECT_V2         9
+#define OPENVPN_PLUGIN_TLS_FINAL                10
+#define OPENVPN_PLUGIN_ENABLE_PF                11
+#define OPENVPN_PLUGIN_ROUTE_PREDOWN            12
+#define OPENVPN_PLUGIN_CLIENT_CONNECT_DEFER     13
+#define OPENVPN_PLUGIN_CLIENT_CONNECT_DEFER_V2  14
+#define OPENVPN_PLUGIN_N                        15
 
 /*
  * Build a mask out of a set of plug-in types.
@@ -121,10 +154,10 @@ typedef void *openvpn_plugin_handle_t;
 /*
  * For Windows (needs to be modified for MSVC)
  */
-#if defined(__MINGW32_VERSION) && !defined(OPENVPN_PLUGIN_H)
-# define OPENVPN_EXPORT __declspec(dllexport)
+#if defined(_WIN32) && !defined(OPENVPN_PLUGIN_H)
+#define OPENVPN_EXPORT __declspec(dllexport)
 #else
-# define OPENVPN_EXPORT
+#define OPENVPN_EXPORT
 #endif
 
 /*
@@ -139,7 +172,7 @@ typedef void *openvpn_plugin_handle_t;
 #define OPENVPN_PLUGIN_DEF        typedef
 #define OPENVPN_PLUGIN_FUNC(name) (*name)
 
-#else
+#else  /* ifdef OPENVPN_PLUGIN_H */
 
 /*
  * We are compiling plugin.
@@ -158,9 +191,269 @@ typedef void *openvpn_plugin_handle_t;
  */
 struct openvpn_plugin_string_list
 {
-  struct openvpn_plugin_string_list *next;
-  char *name;
-  char *value;
+    struct openvpn_plugin_string_list *next;
+    char *name;
+    char *value;
+};
+
+
+/* openvpn_plugin_{open,func}_v3() related structs */
+
+/**
+ * Defines version of the v3 plugin argument structs
+ *
+ * Whenever one or more of these structs are modified, this constant
+ * must be updated.  A changelog should be appended in this comment
+ * as well, to make it easier to see what information is available
+ * in the different versions.
+ *
+ * Version   Comment
+ *    1      Initial plugin v3 structures providing the same API as
+ *           the v2 plugin interface, X509 certificate information +
+ *           a logging API for plug-ins.
+ *
+ *    2      Added ssl_api member in struct openvpn_plugin_args_open_in
+ *           which identifies the SSL implementation OpenVPN is compiled
+ *           against.
+ *
+ *    3      Added ovpn_version, ovpn_version_major, ovpn_version_minor
+ *           and ovpn_version_patch to provide the runtime version of
+ *           OpenVPN to plug-ins.
+ *
+ *    4      Exported secure_memzero() as plugin_secure_memzero()
+ *
+ *    5      Exported openvpn_base64_encode() as plugin_base64_encode()
+ *           Exported openvpn_base64_decode() as plugin_base64_decode()
+ */
+#define OPENVPN_PLUGINv3_STRUCTVER 5
+
+/**
+ * Definitions needed for the plug-in callback functions.
+ */
+typedef enum
+{
+    PLOG_ERR    = (1 << 0),/* Error condition message */
+    PLOG_WARN   = (1 << 1),/* General warning message */
+    PLOG_NOTE   = (1 << 2),/* Informational message */
+    PLOG_DEBUG  = (1 << 3),/* Debug message, displayed if verb >= 7 */
+
+    PLOG_ERRNO  = (1 << 8),/* Add error description to message */
+    PLOG_NOMUTE = (1 << 9), /* Mute setting does not apply for message */
+
+} openvpn_plugin_log_flags_t;
+
+
+#ifdef __GNUC__
+#if __USE_MINGW_ANSI_STDIO
+#define _ovpn_chk_fmt(a, b) __attribute__ ((format(gnu_printf, (a), (b))))
+#else
+#define _ovpn_chk_fmt(a, b) __attribute__ ((format(__printf__, (a), (b))))
+#endif
+#else  /* ifdef __GNUC__ */
+#define _ovpn_chk_fmt(a, b)
+#endif
+
+typedef void (*plugin_log_t)(openvpn_plugin_log_flags_t flags,
+                             const char *plugin_name,
+                             const char *format, ...) _ovpn_chk_fmt (3, 4);
+
+typedef void (*plugin_vlog_t)(openvpn_plugin_log_flags_t flags,
+                              const char *plugin_name,
+                              const char *format,
+                              va_list arglist) _ovpn_chk_fmt (3, 0);
+#undef _ovpn_chk_fmt
+
+/**
+ *  Export of secure_memzero() to be used inside plug-ins
+ *
+ *  @param data   Pointer to data to zeroise
+ *  @param len    Length of data, in bytes
+ *
+ */
+typedef void (*plugin_secure_memzero_t)(void *data, size_t len);
+
+/**
+ *  Export of openvpn_base64_encode() to be used inside plug-ins
+ *
+ *  @param data   Pointer to data to BASE64 encode
+ *  @param size   Length of data, in bytes
+ *  @param *str   Pointer to the return buffer.  This needed memory is
+ *                allocated by openvpn_base64_encode() and needs to be free()d
+ *                after use.
+ *
+ *  @return int   Returns the length of the buffer created, or -1 on error.
+ *
+ */
+typedef int (*plugin_base64_encode_t)(const void *data, int size, char **str);
+
+/**
+ *  Export of openvpn_base64_decode() to be used inside plug-ins
+ *
+ *  @param str    Pointer to the BASE64 encoded data
+ *  @param data   Pointer to the buffer where save the decoded data
+ *  @param size   Size of the destination buffer
+ *
+ *  @return int   Returns the length of the decoded data, or -1 on error or
+ *                if the destination buffer is too small.
+ *
+ */
+typedef int (*plugin_base64_decode_t)(const char *str, void *data, int size);
+
+
+/**
+ * Used by the openvpn_plugin_open_v3() function to pass callback
+ * function pointers to the plug-in.
+ *
+ * plugin_log
+ * plugin_vlog : Use these functions to add information to the OpenVPN log file.
+ *               Messages will only be displayed if the plugin_name parameter
+ *               is set. PLOG_DEBUG messages will only be displayed with plug-in
+ *               debug log verbosity (at the time of writing that's verb >= 7).
+ *
+ * plugin_secure_memzero
+ *             : Use this function to securely wipe sensitive information from
+ *               memory.  This function is declared in a way that the compiler
+ *               will not remove these function calls during the compiler
+ *               optimization phase.
+ */
+struct openvpn_plugin_callbacks
+{
+    plugin_log_t plugin_log;
+    plugin_vlog_t plugin_vlog;
+    plugin_secure_memzero_t plugin_secure_memzero;
+    plugin_base64_encode_t plugin_base64_encode;
+    plugin_base64_decode_t plugin_base64_decode;
+};
+
+/**
+ * Used by the openvpn_plugin_open_v3() function to indicate to the
+ * plug-in what kind of SSL implementation OpenVPN uses.  This is
+ * to avoid SEGV issues when OpenVPN is complied against mbed TLS
+ * and the plug-in against OpenSSL.
+ */
+typedef enum {
+    SSLAPI_NONE,
+    SSLAPI_OPENSSL,
+    SSLAPI_MBEDTLS
+} ovpnSSLAPI;
+
+/**
+ * Arguments used to transport variables to the plug-in.
+ * The struct openvpn_plugin_args_open_in is only used
+ * by the openvpn_plugin_open_v3() function.
+ *
+ * STRUCT MEMBERS
+ *
+ * type_mask : Set by OpenVPN to the logical OR of all script
+ *             types which this version of OpenVPN supports.
+ *
+ * argv : a NULL-terminated array of options provided to the OpenVPN
+ *        "plug-in" directive.  argv[0] is the dynamic library pathname.
+ *
+ * envp : a NULL-terminated array of OpenVPN-set environmental
+ *        variables in "name=value" format.  Note that for security reasons,
+ *        these variables are not actually written to the "official"
+ *        environmental variable store of the process.
+ *
+ * callbacks : a pointer to the plug-in callback function struct.
+ *
+ */
+struct openvpn_plugin_args_open_in
+{
+    const int type_mask;
+    const char **const argv;
+    const char **const envp;
+    struct openvpn_plugin_callbacks *callbacks;
+    const ovpnSSLAPI ssl_api;
+    const char *ovpn_version;
+    const unsigned int ovpn_version_major;
+    const unsigned int ovpn_version_minor;
+    const char *const ovpn_version_patch;
+};
+
+
+/**
+ * Arguments used to transport variables from the plug-in back
+ * to the OpenVPN process.  The struct openvpn_plugin_args_open_return
+ * is only used by the openvpn_plugin_open_v3() function.
+ *
+ * STRUCT MEMBERS
+ *
+ * type_mask  : The plug-in should set this value to the logical OR of all script
+ *              types which the plug-in wants to intercept.  For example, if the
+ *              script wants to intercept the client-connect and client-disconnect
+ *              script types:
+ *
+ *              type_mask = OPENVPN_PLUGIN_MASK(OPENVPN_PLUGIN_CLIENT_CONNECT)
+ *                         | OPENVPN_PLUGIN_MASK(OPENVPN_PLUGIN_CLIENT_DISCONNECT)
+ *
+ * handle :     Pointer to a global plug-in context, created by the plug-in.  This pointer
+ *              is passed on to the other plug-in calls.
+ *
+ * return_list : used to return data back to OpenVPN.
+ *
+ */
+struct openvpn_plugin_args_open_return
+{
+    int type_mask;
+    openvpn_plugin_handle_t handle;
+    struct openvpn_plugin_string_list **return_list;
+};
+
+/**
+ * Arguments used to transport variables to and from the
+ * plug-in.  The struct openvpn_plugin_args_func is only used
+ * by the openvpn_plugin_func_v3() function.
+ *
+ * STRUCT MEMBERS:
+ *
+ * type : one of the PLUGIN_x types.
+ *
+ * argv : a NULL-terminated array of "command line" options which
+ *        would normally be passed to the script.  argv[0] is the dynamic
+ *        library pathname.
+ *
+ * envp : a NULL-terminated array of OpenVPN-set environmental
+ *        variables in "name=value" format.  Note that for security reasons,
+ *        these variables are not actually written to the "official"
+ *        environmental variable store of the process.
+ *
+ * handle : Pointer to a global plug-in context, created by the plug-in's openvpn_plugin_open_v3().
+ *
+ * per_client_context : the per-client context pointer which was returned by
+ *        openvpn_plugin_client_constructor_v1, if defined.
+ *
+ * current_cert_depth : Certificate depth of the certificate being passed over
+ *
+ * *current_cert : X509 Certificate object received from the client
+ *
+ */
+struct openvpn_plugin_args_func_in
+{
+    const int type;
+    const char **const argv;
+    const char **const envp;
+    openvpn_plugin_handle_t handle;
+    void *per_client_context;
+    int current_cert_depth;
+    openvpn_x509_cert_t *current_cert;
+};
+
+
+/**
+ * Arguments used to transport variables to and from the
+ * plug-in.  The struct openvpn_plugin_args_func is only used
+ * by the openvpn_plugin_func_v3() function.
+ *
+ * STRUCT MEMBERS:
+ *
+ * return_list : used to return data back to OpenVPN for further processing/usage by
+ *               the OpenVPN executable.
+ *
+ */
+struct openvpn_plugin_args_func_return
+{
+    struct openvpn_plugin_string_list **return_list;
 };
 
 /*
@@ -194,7 +487,7 @@ struct openvpn_plugin_string_list
  * FUNCTION: openvpn_plugin_open_v2
  *
  * REQUIRED: YES
- * 
+ *
  * Called on initial plug-in load.  OpenVPN will preserve plug-in state
  * across SIGUSR1 restarts but not across SIGHUP restarts.  A SIGHUP reset
  * will cause the plugin to be closed and reopened.
@@ -226,10 +519,10 @@ struct openvpn_plugin_string_list
  * An openvpn_plugin_handle_t value on success, NULL on failure
  */
 OPENVPN_PLUGIN_DEF openvpn_plugin_handle_t OPENVPN_PLUGIN_FUNC(openvpn_plugin_open_v2)
-     (unsigned int *type_mask,
-      const char *argv[],
-      const char *envp[],
-      struct openvpn_plugin_string_list **return_list);
+    (unsigned int *type_mask,
+    const char *argv[],
+    const char *envp[],
+    struct openvpn_plugin_string_list **return_list);
 
 /*
  * FUNCTION: openvpn_plugin_func_v2
@@ -237,7 +530,7 @@ OPENVPN_PLUGIN_DEF openvpn_plugin_handle_t OPENVPN_PLUGIN_FUNC(openvpn_plugin_op
  * Called to perform the work of a given script type.
  *
  * REQUIRED: YES
- * 
+ *
  * ARGUMENTS
  *
  * handle : the openvpn_plugin_handle_t value which was returned by
@@ -258,6 +551,139 @@ OPENVPN_PLUGIN_DEF openvpn_plugin_handle_t OPENVPN_PLUGIN_FUNC(openvpn_plugin_op
  *        openvpn_plugin_client_constructor_v1, if defined.
  *
  * return_list : used to return data back to OpenVPN.
+ *
+ * RETURN VALUE
+ *
+ * OPENVPN_PLUGIN_FUNC_SUCCESS on success, OPENVPN_PLUGIN_FUNC_ERROR on failure
+ *
+ * In addition, OPENVPN_PLUGIN_FUNC_DEFERRED may be returned by
+ * OPENVPN_PLUGIN_AUTH_USER_PASS_VERIFY, OPENVPN_PLUGIN_CLIENT_CONNECT and
+ * OPENVPN_PLUGIN_CLIENT_CONNECT_V2. This enables asynchronous
+ * authentication or client connect  where the plugin (or one of its agents)
+ * may indicate authentication success/failure or client configuration some
+ * number of seconds after the return of the function handler.
+ * For OPENVPN_PLUGIN_AUTH_USER_PASS_VERIFY and OPENVPN_PLUGIN_CLIENT_CONNECT
+ * this is done by writing a single char to the file named by
+ * auth_control_file/client_connect_deferred_file
+ * in the environmental variable list (envp).
+ *
+ * Additionally the auth_pending_file can be written, which causes the openvpn
+ * server to send a pending auth request to the client. See doc/management.txt
+ * for more details on this authentication mechanism. The format of the
+ * auth_pending_file is
+ * line 1: timeout in seconds
+ * line 2: Pending auth method the client needs to support (e.g. openurl)
+ * line 3: EXTRA (e.g. OPEN_URL:http://www.example.com)
+ *
+ * In addition the OPENVPN_PLUGIN_CLIENT_CONNECT_DEFER and
+ * OPENVPN_PLUGIN_CLIENT_CONNECT_DEFER_V2 are called when OpenVPN tries to
+ * get the deferred result. For a V2 call implementing this function is
+ * required as information is not passed by files. For the normal version
+ * the call is optional.
+ *
+ * first char of auth_control_file:
+ * '0' -- indicates auth failure
+ * '1' -- indicates auth success
+ *
+ * OpenVPN will delete the auth_control_file after it goes out of scope.
+ *
+ * If an OPENVPN_PLUGIN_ENABLE_PF handler is defined and returns success
+ * for a particular client instance, packet filtering will be enabled for that
+ * instance.  OpenVPN will then attempt to read the packet filter configuration
+ * from the temporary file named by the environmental variable pf_file.  This
+ * file may be generated asynchronously and may be dynamically updated during the
+ * client session, however the client will be blocked from sending or receiving
+ * VPN tunnel packets until the packet filter file has been generated.  OpenVPN
+ * will periodically test the packet filter file over the life of the client
+ * instance and reload when modified.  OpenVPN will delete the packet filter file
+ * when the client instance goes out of scope.
+ *
+ * Packet filter file grammar:
+ *
+ * [CLIENTS DROP|ACCEPT]
+ * {+|-}common_name1
+ * {+|-}common_name2
+ * . . .
+ * [SUBNETS DROP|ACCEPT]
+ * {+|-}subnet1
+ * {+|-}subnet2
+ * . . .
+ * [END]
+ *
+ * Subnet: IP-ADDRESS | IP-ADDRESS/NUM_NETWORK_BITS
+ *
+ * CLIENTS refers to the set of clients (by their common-name) which
+ * this instance is allowed ('+') to connect to, or is excluded ('-')
+ * from connecting to.  Note that in the case of client-to-client
+ * connections, such communication must be allowed by the packet filter
+ * configuration files of both clients.
+ *
+ * SUBNETS refers to IP addresses or IP address subnets which this
+ * instance may connect to ('+') or is excluded ('-') from connecting
+ * to.
+ *
+ * DROP or ACCEPT defines default policy when there is no explicit match
+ * for a common-name or subnet.  The [END] tag must exist.  A special
+ * purpose tag called [KILL] will immediately kill the client instance.
+ * A given client or subnet rule applies to both incoming and outgoing
+ * packets.
+ *
+ * See plugin/defer/simple.c for an example on using asynchronous
+ * authentication and client-specific packet filtering.
+ */
+OPENVPN_PLUGIN_DEF int OPENVPN_PLUGIN_FUNC(openvpn_plugin_func_v2)
+    (openvpn_plugin_handle_t handle,
+    const int type,
+    const char *argv[],
+    const char *envp[],
+    void *per_client_context,
+    struct openvpn_plugin_string_list **return_list);
+
+
+/*
+ * FUNCTION: openvpn_plugin_open_v3
+ *
+ * REQUIRED: YES
+ *
+ * Called on initial plug-in load.  OpenVPN will preserve plug-in state
+ * across SIGUSR1 restarts but not across SIGHUP restarts.  A SIGHUP reset
+ * will cause the plugin to be closed and reopened.
+ *
+ * ARGUMENTS
+ *
+ * version : fixed value, defines the API version of the OpenVPN plug-in API.  The plug-in
+ *           should validate that this value is matching the OPENVPN_PLUGINv3_STRUCTVER
+ *           value.
+ *
+ * arguments : Structure with all arguments available to the plug-in.
+ *
+ * retptr :    used to return data back to OpenVPN.
+ *
+ * RETURN VALUE
+ *
+ * OPENVPN_PLUGIN_FUNC_SUCCESS on success, OPENVPN_PLUGIN_FUNC_ERROR on failure
+ */
+OPENVPN_PLUGIN_DEF int OPENVPN_PLUGIN_FUNC(openvpn_plugin_open_v3)
+    (const int version,
+    struct openvpn_plugin_args_open_in const *arguments,
+    struct openvpn_plugin_args_open_return *retptr);
+
+/*
+ * FUNCTION: openvpn_plugin_func_v3
+ *
+ * Called to perform the work of a given script type.
+ *
+ * REQUIRED: YES
+ *
+ * ARGUMENTS
+ *
+ * version : fixed value, defines the API version of the OpenVPN plug-in API.  The plug-in
+ *           should validate that this value is matching the OPENVPN_PLUGINv3_STRUCTVER
+ *           value.
+ *
+ * arguments : Structure with all arguments available to the plug-in.
+ *
+ * retptr :    used to return data back to OpenVPN.
  *
  * RETURN VALUE
  *
@@ -318,22 +744,19 @@ OPENVPN_PLUGIN_DEF openvpn_plugin_handle_t OPENVPN_PLUGIN_FUNC(openvpn_plugin_op
  * A given client or subnet rule applies to both incoming and outgoing
  * packets.
  *
- * See plugin/defer/simple.c for an example on using asynchronous
- * authentication and client-specific packet filtering.
+ * See sample/sample-plugins/defer/simple.c for an example on using
+ * asynchronous authentication and client-specific packet filtering.
  */
-OPENVPN_PLUGIN_DEF int OPENVPN_PLUGIN_FUNC(openvpn_plugin_func_v2)
-     (openvpn_plugin_handle_t handle,
-      const int type,
-      const char *argv[],
-      const char *envp[],
-      void *per_client_context,
-      struct openvpn_plugin_string_list **return_list);
+OPENVPN_PLUGIN_DEF int OPENVPN_PLUGIN_FUNC(openvpn_plugin_func_v3)
+    (const int version,
+    struct openvpn_plugin_args_func_in const *arguments,
+    struct openvpn_plugin_args_func_return *retptr);
 
 /*
  * FUNCTION: openvpn_plugin_close_v1
  *
  * REQUIRED: YES
- * 
+ *
  * ARGUMENTS
  *
  * handle : the openvpn_plugin_handle_t value which was returned by
@@ -342,13 +765,13 @@ OPENVPN_PLUGIN_DEF int OPENVPN_PLUGIN_FUNC(openvpn_plugin_func_v2)
  * Called immediately prior to plug-in unload.
  */
 OPENVPN_PLUGIN_DEF void OPENVPN_PLUGIN_FUNC(openvpn_plugin_close_v1)
-     (openvpn_plugin_handle_t handle);
+    (openvpn_plugin_handle_t handle);
 
 /*
  * FUNCTION: openvpn_plugin_abort_v1
  *
  * REQUIRED: NO
- * 
+ *
  * ARGUMENTS
  *
  * handle : the openvpn_plugin_handle_t value which was returned by
@@ -359,7 +782,7 @@ OPENVPN_PLUGIN_DEF void OPENVPN_PLUGIN_FUNC(openvpn_plugin_close_v1)
  * openvpn_plugin_open callback.
  */
 OPENVPN_PLUGIN_DEF void OPENVPN_PLUGIN_FUNC(openvpn_plugin_abort_v1)
-     (openvpn_plugin_handle_t handle);
+    (openvpn_plugin_handle_t handle);
 
 /*
  * FUNCTION: openvpn_plugin_client_constructor_v1
@@ -376,7 +799,7 @@ OPENVPN_PLUGIN_DEF void OPENVPN_PLUGIN_FUNC(openvpn_plugin_abort_v1)
  * return a void * to this memory region.
  *
  * REQUIRED: NO
- * 
+ *
  * ARGUMENTS
  *
  * handle : the openvpn_plugin_handle_t value which was returned by
@@ -387,8 +810,8 @@ OPENVPN_PLUGIN_DEF void OPENVPN_PLUGIN_FUNC(openvpn_plugin_abort_v1)
  * void * pointer to plugin's private per-client memory region, or NULL
  * if no memory region is required.
  */
-OPENVPN_PLUGIN_DEF void * OPENVPN_PLUGIN_FUNC(openvpn_plugin_client_constructor_v1)
-     (openvpn_plugin_handle_t handle);
+OPENVPN_PLUGIN_DEF void *OPENVPN_PLUGIN_FUNC(openvpn_plugin_client_constructor_v1)
+    (openvpn_plugin_handle_t handle);
 
 /*
  * FUNCTION: openvpn_plugin_client_destructor_v1
@@ -396,7 +819,7 @@ OPENVPN_PLUGIN_DEF void * OPENVPN_PLUGIN_FUNC(openvpn_plugin_client_constructor_
  * This function is called on client instance object destruction.
  *
  * REQUIRED: NO
- * 
+ *
  * ARGUMENTS
  *
  * handle : the openvpn_plugin_handle_t value which was returned by
@@ -406,7 +829,7 @@ OPENVPN_PLUGIN_DEF void * OPENVPN_PLUGIN_FUNC(openvpn_plugin_client_constructor_
  *        openvpn_plugin_client_constructor_v1, if defined.
  */
 OPENVPN_PLUGIN_DEF void OPENVPN_PLUGIN_FUNC(openvpn_plugin_client_destructor_v1)
-     (openvpn_plugin_handle_t handle, void *per_client_context);
+    (openvpn_plugin_handle_t handle, void *per_client_context);
 
 /*
  * FUNCTION: openvpn_plugin_select_initialization_point_v1
@@ -419,7 +842,7 @@ OPENVPN_PLUGIN_DEF void OPENVPN_PLUGIN_FUNC(openvpn_plugin_client_destructor_v1)
  * OPENVPN_PLUGIN_INIT_PRE_CONFIG_PARSE.
  *
  * REQUIRED: NO
- * 
+ *
  * RETURN VALUE:
  *
  * An OPENVPN_PLUGIN_INIT_x value.
@@ -430,32 +853,38 @@ OPENVPN_PLUGIN_DEF void OPENVPN_PLUGIN_FUNC(openvpn_plugin_client_destructor_v1)
 #define OPENVPN_PLUGIN_INIT_POST_UID_CHANGE  4
 
 OPENVPN_PLUGIN_DEF int OPENVPN_PLUGIN_FUNC(openvpn_plugin_select_initialization_point_v1)
-     (void);
+    (void);
 
 /*
  * FUNCTION: openvpn_plugin_min_version_required_v1
  *
  * This function is called by OpenVPN to query the minimum
-   plugin interface version number required by the plugin.
+ * plugin interface version number required by the plugin.
  *
  * REQUIRED: NO
- * 
+ *
  * RETURN VALUE
  *
  * The minimum OpenVPN plugin interface version number necessary to support
  * this plugin.
  */
 OPENVPN_PLUGIN_DEF int OPENVPN_PLUGIN_FUNC(openvpn_plugin_min_version_required_v1)
-     (void);
+    (void);
 
 /*
  * Deprecated functions which are still supported for backward compatibility.
  */
 
 OPENVPN_PLUGIN_DEF openvpn_plugin_handle_t OPENVPN_PLUGIN_FUNC(openvpn_plugin_open_v1)
-     (unsigned int *type_mask,
-      const char *argv[],
-      const char *envp[]);
+    (unsigned int *type_mask,
+    const char *argv[],
+    const char *envp[]);
 
 OPENVPN_PLUGIN_DEF int OPENVPN_PLUGIN_FUNC(openvpn_plugin_func_v1)
-     (openvpn_plugin_handle_t handle, const int type, const char *argv[], const char *envp[]);
+    (openvpn_plugin_handle_t handle, const int type, const char *argv[], const char *envp[]);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* OPENVPN_PLUGIN_H_ */

--- a/test_duo_openvpn.py
+++ b/test_duo_openvpn.py
@@ -41,7 +41,7 @@ class TestIntegration(unittest.TestCase):
     SKEY = 'expected skey'
     HOST = 'expected hostname'
     USERNAME = 'expected username'
-    PASSCODE = 'expected passcode'
+    CHALLENGE_TYPE = 'expected challenge-type'
     IPADDR = 'expected_ipaddr'
     PROXY_HOST = 'expected proxy host'
     PROXY_PORT = 'expected proxy port'
@@ -53,7 +53,7 @@ class TestIntegration(unittest.TestCase):
     EXPECTED_AUTH_PATH = '/rest/v1/auth'
     EXPECTED_PREAUTH_PATH = '/rest/v1/preauth'
     EXPECTED_AUTH_PARAMS = (
-        'auto=expected+passcode'
+        'auto=expected+challenge-type'
         '&ipaddr=expected_ipaddr'
         '&user=expected+username'
         '&factor=auto'
@@ -94,7 +94,7 @@ class TestIntegration(unittest.TestCase):
             'skey': self.SKEY,
             'host': self.HOST,
             'username': self.USERNAME,
-            'password': self.PASSCODE,
+            'challenge_type': self.CHALLENGE_TYPE,
             'ipaddr': self.IPADDR,
         }
         self.expected_calls.duo_client_init(
@@ -364,7 +364,7 @@ class TestIntegration(unittest.TestCase):
                 }),
             ),
         )
-        auth_noip_params='auto=expected+passcode' \
+        auth_noip_params='auto=expected+challenge-type' \
             '&ipaddr=0.0.0.0' \
             '&user=expected+username' \
             '&factor=auto'
@@ -394,7 +394,7 @@ class TestIntegration(unittest.TestCase):
             'ikey': self.IKEY,
             'skey': self.SKEY,
             'host': self.HOST,
-            'password': self.PASSCODE,
+            'challenge_type': self.CHALLENGE_TYPE,
             'username': self.USERNAME,
             'ipaddr': self.IPADDR,
         }
@@ -409,7 +409,7 @@ class TestIntegration(unittest.TestCase):
             'ikey': self.IKEY,
             'skey': self.SKEY,
             'host': self.HOST,
-            'password': self.PASSCODE,
+            'challenge_type': self.CHALLENGE_TYPE,
             'ipaddr': self.IPADDR,
         }
         self.assert_auth(
@@ -417,9 +417,9 @@ class TestIntegration(unittest.TestCase):
             expected_control='',
         )
 
-    def test_missing_password(self):
+    def test_missing_challenge_type(self):
         environ = self.normal_environ()
-        del environ['password']
+        del environ['challenge_type']
         self.expect_preauth('auth', factor=None)
         self.assert_auth(
             environ=environ,
@@ -430,7 +430,7 @@ class TestIntegration(unittest.TestCase):
         environ = {
             'skey': self.SKEY,
             'host': self.HOST,
-            'password': self.PASSCODE,
+            'challenge_type': self.CHALLENGE_TYPE,
             'username': self.USERNAME,
             'ipaddr': self.IPADDR,
         }
@@ -443,7 +443,7 @@ class TestIntegration(unittest.TestCase):
         environ = {
             'ikey': self.IKEY,
             'host': self.HOST,
-            'password': self.PASSCODE,
+            'challenge_type': self.CHALLENGE_TYPE,
             'username': self.USERNAME,
             'ipaddr': self.IPADDR,
         }
@@ -456,7 +456,7 @@ class TestIntegration(unittest.TestCase):
         environ = {
             'ikey': self.IKEY,
             'skey': self.SKEY,
-            'password': self.PASSCODE,
+            'challenge_type': self.CHALLENGE_TYPE,
             'username': self.USERNAME,
             'ipaddr': self.IPADDR,
         }


### PR DESCRIPTION
The plugin currently has 3 required host and key parameters, plus 2 optional (largely undocumented) proxy parameters. Adding additional parameters in the future will be challenging as the current method of referring to positional parameters when parsing the configuration cannot handle more than one parameter - or set of related parameters - being optional.

Additionally, OpenVPN will log the parameters passed to a plugin during initialisation under some logging levels which would result in the integration key, associated secret, and target host being printed to OpenVPN server logs which would then leak those values to anyone with access to the OpenVPN logs.

To support multiple sets of optional parameters being allowed, an additional `--config-file=...` parameter has been added to the plugin launch arguments, with the plugin configuration then being loaded from this file if the parameter is specified. The format of the file is `name value` pairs separated by a single whitespace, with any blank lines or those prefixed by a `#` being skipped during parsing. Any other lines that do not start with a recognised configuration property result in the configuration parsing being terminated with an error.

To allow fall-back for anyone specifying a legacy configuration, support for parsing positional parameters as currently supported by the plugin has been retained, although an attempt to use old and new configuration options results in the plugin failing to start.

The plugin has also been updated to use the `v3` plugin structure of Open VPN which allows returning an error state from the plugin `open` phase, as well as providing the ability to report messages into the Open VPN log, thereby allowing for reporting when the plugin is not configured properly. The fallback positional parsing now logs a message in the Open VPN log warning the user they're using an out-dated configuration approach.

Additional configuration options have been added to allow an Open VPN administrator to decide which Duo challenges are enabled for different Open VPN authentication types - currently one of certificate or username and password - with the appropriate challenge types then being requested based on the authentication type actually requested by the user during connection attempts.

Where username and password is being used, only push or phone options are allowed to be configured, as the user has no way of entering a fall-back code or notifying that they would like to receive backup codes, with the administrator only being allowed to configure one of these two options since there's no way of a user selecting a preferred option during their authentication attempt. The certificate based authentication mechanism retains the same possible options as before, although the administrator now has an option for which mechanisms are enabled from the allowed list. For security, no authentication approaches are initially turned on, and no challenge mechanisms are enabled so that an administrator must select the specific options they want to have supported. If they fail to enable any options or enable an invalid combination of options then the plugin will log an appropriate error and return an error code to Open VPN which will result in the server failing to start. Similarly, checks are performed on the user's inputs and errors logged if any inputs are not appropriate for the currently enabled authentication and challenge mechanisms, with the challenge attempt then being aborted before calling the Duo APIs.

For backwards compatibility with old installations, any configuration that's using positional parameter parsing rather than a configuration file has username and password authentication disabled for challenges, and has all the certificate authentication challenges enabled.
