### PR TITLE
Drop Python 2 support

### DIFF
--- a/duo_openvpn.py
+++ b/duo_openvpn.py
@@ -16,10 +16,9 @@ import os
 import socket
 import sys
 import syslog
+import http.client as http_client
+import urllib.parse as urllib_parse
 
-import six
-from six.moves import http_client
-from six.moves.urllib.parse import quote, urlencode
 
 def log(msg):
     msg = 'Duo OpenVPN: %s' % msg
@@ -50,8 +49,8 @@ def canon_params(params):
     # http://tools.ietf.org/html/rfc5849#section-3.4.1.3.2
     args = []
     for (key, vals) in sorted(
-        (quote(key, '~'), vals) for (key, vals) in params.items()):
-        for val in sorted(quote(val, '~') for val in vals):
+        (urllib_parse.quote(key, '~'), vals) for (key, vals) in params.items()):
+        for val in sorted(urllib_parse.quote(val, '~') for val in vals):
             args.append('%s=%s' % (key, val))
     return '&'.join(args)
 
@@ -80,19 +79,19 @@ def sign(ikey, skey, method, host, uri, date, sig_version, params):
     """
     canonical = canonicalize(method, host, uri, params, date, sig_version)
 
-    if isinstance(skey, six.text_type):
+    if isinstance(skey, str):
         skey = skey.encode('utf-8')
-    if isinstance(canonical, six.text_type):
+    if isinstance(canonical, str):
         canonical = canonical.encode('utf-8')
 
     sig = hmac.new(skey, canonical, hashlib.sha512)
     auth = '%s:%s' % (ikey, sig.hexdigest())
 
-    if isinstance(auth, six.text_type):
+    if isinstance(auth, str):
         auth = auth.encode('utf-8')
 
     b64 = base64.b64encode(auth)
-    if not isinstance(b64, six.text_type):
+    if isinstance(b64, str):
         b64 = b64.decode('utf-8')
 
     return 'Basic %s' % b64
@@ -106,12 +105,12 @@ def normalize_params(params):
     # urllib cannot handle unicode strings properly. quote() excepts,
     # and urlencode() replaces them with '?'.
     def encode(value):
-        if isinstance(value, six.text_type):
+        if isinstance(value, str):
             return value.encode("utf-8")
         return value
 
     def to_list(value):
-        if value is None or isinstance(value, six.string_types):
+        if value is None or isinstance(value, str):
             return [value]
         return value
 
@@ -185,11 +184,11 @@ class Client(object):
 
         if method in ['POST', 'PUT']:
             headers['Content-type'] = 'application/x-www-form-urlencoded'
-            body = urlencode(params, doseq=True)
+            body = urllib_parse.urlencode(params, doseq=True)
             uri = path
         else:
             body = None
-            uri = path + '?' + urlencode(params, doseq=True)
+            uri = path + '?' + urllib_parse.urlencode(params, doseq=True)
 
         return self._make_request(method, uri, body, headers)
 
@@ -278,7 +277,7 @@ class Client(object):
             error.data = data
             raise error
 
-        if not isinstance(data, six.text_type):
+        if not isinstance(data, str):
             data = data.decode('utf-8')
 
         if response.status != 200:
@@ -293,14 +292,14 @@ class Client(object):
                         ))
                     else:
                         raise_error('Received %s %s' % (
-                                response.status,
+                            response.status,
                             data['message'],
                         ))
             except (ValueError, KeyError, TypeError):
                 pass
             raise_error('Received %s %s' % (
-                    response.status,
-                    response.reason,
+                response.status,
+                response.reason,
             ))
         try:
             data = json.loads(data)
@@ -313,18 +312,16 @@ class Client(object):
 def success(control):
     log('writing success code to %s' % control)
 
-    f = open(control, 'w')
-    f.write('1')
-    f.close()
+    with open(control, 'w') as f:
+        f.write('1')
 
     sys.exit(0)
 
 def failure(control):
     log('writing failure code to %s' % control)
 
-    f = open(control, 'w')
-    f.write('0')
-    f.close()
+    with open(control, 'w') as f:
+        f.write('0')
 
     sys.exit(1)
 

--- a/https_wrapper.py
+++ b/https_wrapper.py
@@ -22,9 +22,9 @@
 import re
 import socket
 import ssl
-
-from six.moves import http_client
-from six.moves import urllib
+import http.client as http_client
+import urllib.request
+import urllib.error
 
 
 class InvalidCertificateException(http_client.HTTPException):
@@ -37,7 +37,7 @@ class InvalidCertificateException(http_client.HTTPException):
       host: The hostname the connection was made to.
       cert: The SSL certificate (as a dictionary) the host returned.
     """
-    http_client.HTTPException.__init__(self)
+    super().__init__()
     self.host = host
     self.cert = cert
     self.reason = reason
@@ -68,7 +68,7 @@ class CertValidatingHTTPSConnection(http_client.HTTPConnection):
       strict: When true, causes BadStatusLine to be raised if the status line
           can't be parsed as a valid HTTP/1.0 or 1.1 status line.
     """
-    http_client.HTTPConnection.__init__(self, host, port, strict, **kwargs)
+    super().__init__(host, port, strict, **kwargs)
     self.key_file = key_file
     self.cert_file = cert_file
     self.ca_certs = ca_certs
@@ -136,7 +136,7 @@ class CertValidatingHTTPSHandler(urllib.request.HTTPSHandler):
 
   def __init__(self, **kwargs):
     """Constructor. Any keyword args are passed to the http_client handler."""
-    urllib.request.HTTPSHandler.__init__(self)
+    super().__init__()
     self._connection_args = kwargs
 
   def https_open(self, req):
@@ -147,9 +147,9 @@ class CertValidatingHTTPSHandler(urllib.request.HTTPSHandler):
     try:
       return self.do_open(http_class_wrapper, req)
     except urllib.error.URLError as e:
-      if type(e.reason) == ssl.SSLError and e.reason.args[0] == 1:
+      if isinstance(e.reason, ssl.SSLError) and e.reason.args[0] == 1:
         raise InvalidCertificateException(req.host, '',
                                           e.reason.args[1])
       raise
 
-  https_request = urllib.request.HTTPSHandler.do_request_
+https_request = urllib.request.HTTPSHandler.do_request_


### PR DESCRIPTION
## Description
This PR removes all uses of Python 2.

## Motivation and Context
Fixes [issue 50](https://github.com/duosecurity/duo_openvpn/issues/50)

## How Has This Been Tested?
Test module `test_duo_openvpn.py` was adapted to use `unittest.mock` instead of `mox`. 
Tests passing.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
