### PR TITLE
Remove python 3.7 from CI

### DIFF
--- a/.github/workflows/openvpn-ci.yml
+++ b/.github/workflows/openvpn-ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## Description
Since Python 3.7 isn't available on ubuntu anymore, remove it from testing

## Motivation and Context
Gets CI working again

## How Has This Been Tested?
N/A

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] CI/test management
