### PR TITLE
Fix IPv6 support

### DIFF
--- a/duo_openvpn.c
+++ b/duo_openvpn.c
@@ -55,6 +55,10 @@ auth_user_pass_verify(struct context *ctx, const char *args[], const char *envp[
 	username = get_env("common_name", envp);
 	password = get_env("password", envp);
 	ipaddr = get_env("untrusted_ip", envp);
+	if (ipaddr == NULL) {
+		/* If untrusted_ip is not set, use untrusted_ip6 because it must be using IPv6 */
+		ipaddr = get_env("untrusted_ip6", envp);
+	}
 
 	if (!control || !username || !password || !ipaddr) {
 		return OPENVPN_PLUGIN_FUNC_ERROR;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When using OpenVPN on an ipv6-enabled network, `untrusted_ip6` is used instead of `untrusted_ip`.

This modifies the code to handle either scenario.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To ensure compatibility with IPv6 as the internet (eventually) moves to it.

## How Has This Been Tested?
<!--- Please describe how you tested your changes, or what tests were added -->
Successfully tested using a local test instance, with IPv4-only, IPv4/IPv6-dual-stack, and IPv6-only.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
